### PR TITLE
Add support for multiversion docs hosted via github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - develop
     paths:
       - .pre-commit-config.yaml
       - .github/workflows/docs.yml
@@ -24,7 +23,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
     paths:
       - .pre-commit-config.yaml
       - .github/workflows/docs.yml
@@ -38,6 +36,15 @@ on:
       - mkdocs.yml
       - '**.png'
       - '**.svg'
+  release:
+    types: [published]
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 0.5.0, latest)'
+        required: true
+        default: 'latest'
 
 jobs:
   build:
@@ -45,6 +52,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0  # Fetch all history for proper versioning
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -75,11 +84,27 @@ jobs:
 
   deploy:
     needs: build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0  # Fetch all history for proper versioning
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.21"
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install the project
+        run: uv sync --all-extras --group docs
 
       - name: Configure Git Credentials
         run: |
@@ -95,8 +120,54 @@ jobs:
       - name: Ensure .nojekyll exists
         run: touch site/.nojekyll
 
-      - name: Deploy to Github pages
-        uses: JamesIves/github-pages-deploy-action@v4.7.3
-        with:
-          branch: gh-pages
-          folder: site
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Use the version provided in the workflow dispatch
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "VERSION_ALIAS=latest" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            # Use the tag from the release
+            VERSION="${{ github.ref_name }}"
+            # Remove 'v' prefix if present
+            VERSION="${VERSION#v}"
+            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+            echo "VERSION_ALIAS=latest" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            # For pushes to main, tag as "main"
+            echo "VERSION=main" >> $GITHUB_OUTPUT
+            # No alias for main
+            echo "VERSION_ALIAS=" >> $GITHUB_OUTPUT
+          else
+            # Get version from pyproject.toml as fallback
+            VERSION=$(grep -m 1 '^version = ' pyproject.toml | sed 's/^version = "\(.*\)"$/\1/')
+            echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+            echo "VERSION_ALIAS=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy docs with mike
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          ALIAS=${{ steps.version.outputs.VERSION_ALIAS }}
+
+          # Add a temporary remote to fetch gh-pages if it exists
+          git remote add temp https://github.com/${{ github.repository }}.git || true
+          git fetch temp gh-pages || true
+
+          DEPLOY_ARGS="--push --update-aliases $VERSION"
+
+          if [[ ! -z "$ALIAS" ]]; then
+            DEPLOY_ARGS="$DEPLOY_ARGS $ALIAS"
+          fi
+
+          echo "Running: mike deploy $DEPLOY_ARGS"
+          mike deploy $DEPLOY_ARGS
+
+          # Set default version to latest only if we're deploying a version with the latest alias
+          if [[ ! -z "$ALIAS" && "$ALIAS" == "latest" ]]; then
+            mike set-default --push latest
+          fi
+
+          # Remove the temporary remote
+          git remote remove temp || true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,176 @@
+# Contributing to Vector Inference
+
+Thank you for your interest in contributing to Vector Inference! This guide will help you get started with development, testing, and documentation contributions.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.10 or newer
+- [uv](https://github.com/astral-sh/uv) for dependency management
+
+### Setting Up Development Environment
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/VectorInstitute/vector-inference.git
+   cd vector-inference
+   ```
+
+2. Install development dependencies:
+   ```bash
+   uv sync --all-extras --group dev
+   ```
+
+3. Install pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+
+!!! tip "Using Virtual Environments"
+    If you prefer using virtual environments, you can use `uv venv` to create one:
+    ```bash
+    uv venv
+    source .venv/bin/activate  # On Linux/macOS
+    # or
+    .venv\Scripts\activate  # On Windows
+    ```
+
+## Development Workflow
+
+### Code Style and Linting
+
+We use several tools to ensure code quality:
+
+- **ruff** for linting and formatting
+- **mypy** for type checking
+
+You can run these tools with:
+
+```bash
+# Linting
+uv run ruff check .
+
+# Type checking
+uv run mypy
+
+# Format code
+uv run ruff format .
+```
+
+!!! note "Pre-commit Hooks"
+    The pre-commit hooks will automatically run these checks before each commit.
+    If the hooks fail, you will need to fix the issues before you can commit.
+
+### Testing
+
+All new features and bug fixes should include tests. We use pytest for testing:
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run tests with coverage
+uv run pytest --cov=vec_inf
+```
+
+## Documentation
+
+### Documentation Setup
+
+Install the documentation dependencies:
+
+```bash
+uv sync --group docs
+```
+
+### Building Documentation
+
+Build and serve the documentation locally:
+
+```bash
+# Standard build
+mkdocs build
+
+# Serve locally with hot-reload
+mkdocs serve
+```
+
+### Versioned Documentation
+
+Vector Inference uses [mike](https://github.com/jimporter/mike) to manage versioned documentation. This allows users to access documentation for specific versions of the library.
+
+#### Available Versions
+
+The documentation is available in multiple versions:
+
+- `latest` - Always points to the most recent stable release
+- Version-specific documentation (e.g., `0.5.0`, `0.4.0`)
+
+#### Versioning Strategy
+
+Our versioning strategy follows these rules:
+
+1. Each release gets its own version number matching the package version (e.g., `0.5.0`)
+2. The `latest` alias always points to the most recent stable release
+3. Documentation is automatically deployed when changes are pushed to the main branch
+
+#### Working with Mike Locally
+
+To preview or work with versioned documentation:
+
+```bash
+# Build and deploy a specific version to your local gh-pages branch
+mike deploy 0.5.0
+
+# Add an alias for the latest version
+mike deploy 0.5.0 latest
+
+# Set the default version to redirect to
+mike set-default latest
+
+# View the deployed versions
+mike list
+
+# Serve the versioned documentation locally
+mike serve
+```
+
+#### Automatic Documentation Deployment
+
+Documentation is automatically deployed through GitHub Actions:
+
+- On pushes to `main`, documentation is deployed with the version from `pyproject.toml` and the `latest` alias
+- Through manual trigger in the GitHub Actions workflow, where you can specify the version to deploy
+
+!!! info "When to Update Documentation"
+    - When adding new features
+    - When changing existing APIs
+    - When fixing bugs that affect user experience
+    - When improving explanations or examples
+
+## Pull Request Process
+
+1. **Fork the repository** and create your branch from `main`
+2. **Make your changes** and add appropriate tests
+3. **Ensure tests pass** and code meets style guidelines
+4. **Write clear documentation** for your changes
+5. **Submit a pull request** with a clear description of the changes
+
+!!! important "Checklist Before Submitting PR"
+    - [ ] All tests pass
+    - [ ] Code is formatted with ruff
+    - [ ] Type annotations are correct
+    - [ ] Documentation is updated
+    - [ ] Commit messages are clear and descriptive
+
+## Release Process
+
+1. Update version in `pyproject.toml`
+2. Update changelogs and documentation as needed
+3. Create a new tag and release on GitHub
+4. Documentation for the new version will be automatically deployed
+
+## License
+
+By contributing to Vector Inference, you agree that your contributions will be licensed under the project's [MIT License](https://github.com/VectorInstitute/vector-inference/blob/main/LICENSE).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,9 +31,7 @@ Thank you for your interest in contributing to Vector Inference! This guide will
     If you prefer using virtual environments, you can use `uv venv` to create one:
     ```bash
     uv venv
-    source .venv/bin/activate  # On Linux/macOS
-    # or
-    .venv\Scripts\activate  # On Windows
+    source .venv/bin/activate
     ```
 
 ## Development Workflow

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -89,3 +89,66 @@
   opacity: 0.7;
   margin-right: 0.2em;
 }
+
+/* Mike version selector styling */
+.md-header__topic {
+  display: flex;
+  align-items: center;
+}
+
+.md-version-select {
+  margin-left: 0.6rem;
+}
+
+.md-version__current {
+  cursor: pointer;
+  color: var(--md-primary-bg-color);
+  font-weight: 700;
+  font-size: 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+  padding: 0.2rem 0.4rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+.md-version__current::after {
+  display: inline-block;
+  content: "";
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid currentColor;
+  margin-left: 0.4rem;
+}
+
+.md-version__list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background-color: var(--md-primary-fg-color);
+  border-radius: 4px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  z-index: 2;
+  min-width: 150px;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s;
+}
+
+.md-version:hover .md-version__list {
+  max-height: 300px;
+}
+
+.md-version__link {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: var(--md-primary-bg-color);
+  font-size: 0.8rem;
+  transition: background-color 0.25s;
+}
+
+.md-version__link:hover {
+  background-color: var(--md-primary-fg-color--dark);
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -90,65 +90,146 @@
   margin-right: 0.2em;
 }
 
-/* Mike version selector styling */
-.md-header__topic {
-  display: flex;
-  align-items: center;
+/* Version selector styling - Material theme */
+
+/* Version selector container */
+.md-version {
+  position: relative;
+  display: inline-block;
+  margin-left: 0.25rem;
 }
 
-.md-version-select {
-  margin-left: 0.6rem;
-}
-
+/* Current version button styling */
 .md-version__current {
-  cursor: pointer;
-  color: var(--md-primary-bg-color);
-  font-weight: 700;
-  font-size: 0.8rem;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 4px;
-  padding: 0.2rem 0.4rem;
   display: inline-flex;
   align-items: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--md-primary-bg-color);
+  padding: 0.4rem 0.8rem;
+  margin: 0.4rem 0;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+  transition: all 0.15s ease-in-out;
 }
 
-.md-version__current::after {
+/* Hover effect for current version button */
+.md-version__current:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Down arrow for version dropdown */
+.md-version__current:after {
   display: inline-block;
+  margin-left: 0.5rem;
   content: "";
-  width: 0;
-  height: 0;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  border-top: 4px solid currentColor;
-  margin-left: 0.4rem;
+  vertical-align: middle;
+  border-top: 0.3em solid;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0;
+  border-left: 0.3em solid transparent;
 }
 
+/* Dropdown menu */
 .md-version__list {
   position: absolute;
   top: 100%;
   left: 0;
+  z-index: 10;
+  min-width: 125%;
+  margin: 0.1rem 0 0;
+  padding: 0;
   background-color: var(--md-primary-fg-color);
   border-radius: 4px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-  z-index: 2;
-  min-width: 150px;
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.25s;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px);
+  transition: all 0.2s ease;
 }
 
+/* Show dropdown when parent is hovered */
 .md-version:hover .md-version__list {
-  max-height: 300px;
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
 }
 
+/* Version list items */
+.md-version__item {
+  list-style: none;
+  padding: 0;
+}
+
+/* Version links */
 .md-version__link {
   display: block;
   padding: 0.5rem 1rem;
+  font-size: 0.75rem;
   color: var(--md-primary-bg-color);
-  font-size: 0.8rem;
-  transition: background-color 0.25s;
+  transition: background-color 0.15s;
+  text-decoration: none;
 }
 
+/* Version link hover */
 .md-version__link:hover {
   background-color: var(--md-primary-fg-color--dark);
+  text-decoration: none;
+}
+
+/* Active version in dropdown */
+.md-version__link--active {
+  background-color: var(--md-accent-fg-color);
+  color: var(--md-accent-bg-color);
+  font-weight: 700;
+}
+
+/* For the Material selector */
+.md-header__option {
+  display: flex;
+  align-items: center;
+}
+
+/* Version selector in Material 9.x */
+.md-select {
+  position: relative;
+  margin-left: 0.5rem;
+}
+
+.md-select__label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--md-primary-bg-color);
+  cursor: pointer;
+  padding: 0.4rem 0.8rem;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  transition: all 0.15s ease-in-out;
+}
+
+.md-select__label:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Version selector in Material 9.2+ */
+.md-header__button.md-select {
+  display: inline-flex;
+  align-items: center;
+  margin: 0 0.8rem;
+}
+
+/* For Material 9.x+ with specific version selector */
+.md-typeset .md-version-warn {
+  padding: 0.6rem 1rem;
+  margin: 1.5rem 0;
+  background-color: rgba(235, 8, 138, 0.1);
+  border-left: 4px solid #eb088a;
+  border-radius: 0.2rem;
+  color: var(--md-default-fg-color);
+  font-size: 0.8rem;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,9 @@ extra:
       link: 404.html
     - icon: fontawesome/brands/github
       link: https://github.com/VectorInstitute/vector-inference
+  version:
+    provider: mike
+    default: latest
 markdown_extensions:
   - attr_list
   - admonition
@@ -38,6 +41,7 @@ plugins:
       css_dir: stylesheets
       canonical_version: latest
       alias_type: symlink
+      deploy_prefix: ''
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -57,7 +61,9 @@ plugins:
 repo_url: https://github.com/VectorInstitute/vector-inference
 repo_name: VectorInstitute/vector-inference
 site_name: Vector Inference
+site_url: https://vectorinstitute.github.io/vector-inference/
 theme:
+  name: material
   custom_dir: docs/overrides
   favicon: assets/favicon-48x48.svg
   features:
@@ -67,6 +73,7 @@ theme:
     - navigation.indexes
     - navigation.instant
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.top
     - search.suggest
     - search.highlight
@@ -75,7 +82,6 @@ theme:
     repo: fontawesome/brands/github
   logo: assets/vector-logo.svg
   logo_footer: assets/vector-logo.svg
-  name: material
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,8 +30,14 @@ nav:
   - Home: index.md
   - User Guide: user_guide.md
   - API Reference: api.md
+  - Contributing: contributing.md
 plugins:
   - search
+  - mike:
+      version_selector: true
+      css_dir: stylesheets
+      canonical_version: latest
+      alias_type: symlink
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ docs = [
     "mkdocstrings>=0.24.1",
     "mkdocstrings-python>=1.8.0",
     "pymdown-extensions>=10.7.1",
+    "mike>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1046,6 +1046,15 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "6.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1408,6 +1417,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354 },
+]
+
+[[package]]
+name = "mike"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "importlib-resources" },
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/f7/2933f1a1fb0e0f077d5d6a92c6c7f8a54e6128241f116dff4df8b6050bbf/mike-2.1.3.tar.gz", hash = "sha256:abd79b8ea483fb0275b7972825d3082e5ae67a41820f8d8a0dc7a3f49944e810", size = 38119 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/1a/31b7cd6e4e7a02df4e076162e9783620777592bea9e4bb036389389af99d/mike-2.1.3-py3-none-any.whl", hash = "sha256:d90c64077e84f06272437b464735130d380703a76a5738b152932884c60c062a", size = 33754 },
 ]
 
 [[package]]
@@ -3652,6 +3680,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings" },
@@ -3689,11 +3718,21 @@ dev = [
     { name = "ruff", specifier = ">=0.9.6" },
 ]
 docs = [
+    { name = "mike", specifier = ">=2.0.0" },
     { name = "mkdocs", specifier = ">=1.5.3" },
     { name = "mkdocs-material", specifier = ">=9.5.12" },
     { name = "mkdocstrings", specifier = ">=0.24.1" },
     { name = "mkdocstrings-python", specifier = ">=1.8.0" },
     { name = "pymdown-extensions", specifier = ">=10.7.1" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640 },
 ]
 
 [[package]]


### PR DESCRIPTION
# PR Type
Documentation, enhancement

# Short Description
- Add support for multi-version docs hosted via github pages
- Remove the develop branch references in the github workflows, we are not using a develop branch anymore
- Every time there is a PR, the building of docs happens in CI, but nothing is deployed. The main branch documentation is tagged as "main", while releases create a versioned doc with the "latest" alias for the latest one.

To test locally:

1. `uv sync --dev --group docs`
2. `mike deploy 0.5.0 latest`
3. `mike deploy main`
4. `mike set-default 0.5.0`
5. `mike serve`

Note that previous versions like 0.4.0, etc won't have docs. We would have to manually add them if needed.
