### PR TITLE
Fix broken docs workflow, missed venv activate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -161,6 +161,9 @@ jobs:
             DEPLOY_ARGS="$DEPLOY_ARGS $ALIAS"
           fi
 
+          # Activate the virtual environment
+          source .venv/bin/activate
+
           echo "Running: mike deploy $DEPLOY_ARGS"
           mike deploy $DEPLOY_ARGS
 


### PR DESCRIPTION
# PR Type
Fix

- The CI workflow didn't activate the virtual environment, and hence `mike` wasn't found in PATH. 
