### PR TITLE
Update docker workflow to run when uv.lock is updated

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,13 +9,14 @@ on:
     paths:
       - Dockerfile
       - .github/workflows/docker.yml
+      - uv.lock
   pull_request:
     branches:
       - main
-      - develop
     paths:
       - Dockerfile
       - .github/workflows/docker.yml
+      - uv.lock
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
# PR Type
Fix, CI

# Short Description
- When the uv.lock file is updated via a PR, it will trigger the docker build and push workflow. It will be tagged with the pr id, so it can be tested out.
- Existing conditions to run again or merge to main and releases are kept as is.
- Removed `develop` branch condition since its not used
