### PR TITLE
added cleanup command functionality to cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Note that there are other parameters that can also be added to the config but no
 * `metrics`: Streams performance metrics to the console.
 * `shutdown`: Shutdown a model by providing its Slurm job ID.
 * `list`: List all available model names, or view the default/cached configuration of a specific model, `--json-mode` supported.
+* `cleanup`: Remove old log directories. You can filter by `--model-family`, `--model-name`, and/or `--job-id`. Use `--dry-run` to preview what would be deleted.
 
 For more details on the usage of these commands, refer to the [User Guide](https://vectorinstitute.github.io/vector-inference/user_guide/)
 

--- a/vec_inf/README.md
+++ b/vec_inf/README.md
@@ -5,5 +5,6 @@
 * `metrics`: Streams performance metrics to the console.
 * `shutdown`: Shutdown a model by providing its Slurm job ID.
 * `list`: List all available model names, or view the default/cached configuration of a specific model, `--json-mode` supported.
+* `cleanup`: Remove old log directories. You can filter by `--model-family`, `--model-name`, and/or `--job-id`. Use `--dry-run` to preview what would be deleted.
 
 Use `--help` to see all available options

--- a/vec_inf/client/_utils.py
+++ b/vec_inf/client/_utils.py
@@ -285,3 +285,65 @@ def parse_launch_output(output: str) -> tuple[str, dict[str, str]]:
             config_dict[key.lower().replace(" ", "_")] = value
 
     return slurm_job_id, config_dict
+
+
+def find_matching_dirs(
+    log_dir: Path,
+    model_family: Optional[str] = None,
+    model_name: Optional[str] = None,
+    job_id: Optional[int] = None,
+) -> list[Path]:
+    """
+    Find log directories based on filtering criteria.
+
+    Parameters
+    ----------
+    log_dir : Path
+        The base directory containing model family directories.
+    model_family : str, optional
+        Filter to only search inside this family.
+    model_name : str, optional
+        Filter to only match model names.
+    job_id : int, optional
+        Filter to only match this exact SLURM job ID.
+
+    Returns
+    -------
+    list[Path]
+        List of directories that match the criteria and can be deleted.
+    """
+    matched = []
+
+    if not log_dir.exists() or not log_dir.is_dir():
+        raise FileNotFoundError(f"Log directory does not exist: {log_dir}")
+
+    if not model_family and not model_name and not job_id:
+        return [log_dir]
+
+    # Iterate over model families
+    for family_dir in log_dir.iterdir():
+        if not family_dir.is_dir():
+            continue
+        if model_family and family_dir.name != model_family:
+            continue
+
+        if model_family and not model_name and not job_id:
+            return [family_dir]
+
+        for job_dir in family_dir.iterdir():
+            if not job_dir.is_dir():
+                continue
+
+            try:
+                name_part, id_part = job_dir.name.rsplit(".", 1)
+                parsed_id = int(id_part)
+            except ValueError:
+                continue
+
+            if model_name and name_part != model_name:
+                continue
+            if job_id is not None and parsed_id != job_id:
+                continue
+
+            matched.append(job_dir)
+    return matched

--- a/vec_inf/client/api.py
+++ b/vec_inf/client/api.py
@@ -10,8 +10,10 @@ vec_inf.client._helper : Helper classes for model inference server management
 vec_inf.client.models : Data models for API responses
 """
 
+import shutil
 import time
 import warnings
+from pathlib import Path
 from typing import Any, Optional, Union
 
 from vec_inf.client._exceptions import (
@@ -24,7 +26,7 @@ from vec_inf.client._helper import (
     ModelStatusMonitor,
     PerformanceMetricsCollector,
 )
-from vec_inf.client._utils import run_bash_command
+from vec_inf.client._utils import find_matching_dirs, run_bash_command
 from vec_inf.client.config import ModelConfig
 from vec_inf.client.models import (
     LaunchOptions,
@@ -59,6 +61,9 @@ class VecInfClient:
         Shutdown a running model
     wait_until_ready(slurm_job_id, timeout_seconds, poll_interval_seconds, log_dir)
         Wait for a model to become ready
+
+    cleanup_logs(log_dir, model_name, model_family, job_id, dry_run)
+        Remove logs from the log directory.
 
     Examples
     --------
@@ -300,3 +305,47 @@ class VecInfClient:
 
             # Wait before checking again
             time.sleep(poll_interval_seconds)
+
+    def cleanup_logs(
+        self,
+        log_dir: Optional[Union[str, Path]] = None,
+        model_family: Optional[str] = None,
+        model_name: Optional[str] = None,
+        job_id: Optional[int] = None,
+        dry_run: bool = False,
+    ) -> list[Path]:
+        """Remove logs from the log directory.
+
+        Parameters
+        ----------
+        log_dir : str or Path, optional
+            Root directory containing log files. Defaults to ~/.vec-inf-logs.
+        model_family : str, optional
+            Only delete logs for this model family.
+        model_name : str, optional
+            Only delete logs for this model name.
+        job_id : int, optional
+            If provided, only match directories with this exact SLURM job ID.
+        dry_run : bool
+            If True, return matching files without deleting them.
+
+        Returns
+        -------
+        list[Path]
+            List of deleted (or matched if dry_run) log file paths.
+        """
+        log_root = Path(log_dir) if log_dir else Path.home() / ".vec-inf-logs"
+        matched = find_matching_dirs(
+            log_dir=log_root,
+            model_family=model_family,
+            model_name=model_name,
+            job_id=job_id,
+        )
+
+        if dry_run:
+            return matched
+
+        for path in matched:
+            shutil.rmtree(path)
+
+        return matched


### PR DESCRIPTION
# Short Description
This pull request introduces a new `cleanup` command to the CLI, enabling users to remove old log directories with optional filters. It includes updates to the documentation, CLI interface, and client API to support this functionality. 

## New `cleanup` Command Implementation:

* Added a `cleanup` command to the CLI in `vec_inf/cli/_cli.py`. This command allows users to filter and remove log directories based on criteria such as `--model-family`, `--model-name`, and `--job-id`. A `--dry-run` option is also available to preview deletions without performing them.

* Implemented the `cleanup_logs` method in the `VecInfClient` class in `vec_inf/client/api.py`. This method handles the logic for finding and deleting log directories, with support for the same filtering options as the CLI command.

* Added the `find_matching_dirs` utility function in `vec_inf/client/_utils.py` to locate directories matching the specified filters. This function is used by the `cleanup_logs` method to identify directories for deletion.
