### PR TITLE
Bugfix/multinode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ models:
     vllm_args:
       --max-model-len: 1010000
       --max-num-seqs: 256
-      --compilation-confi: 3
+      --compilation-config: 3
 ```
 
 You would then set the `VEC_INF_CONFIG` path using:
@@ -94,7 +94,11 @@ You would then set the `VEC_INF_CONFIG` path using:
 export VEC_INF_CONFIG=/h/<username>/my-model-config.yaml
 ```
 
-Note that there are other parameters that can also be added to the config but not shown in this example, check the [`ModelConfig`](vec_inf/client/config.py) for details.
+**NOTE** 
+* There are other parameters that can also be added to the config but not shown in this example, check the [`ModelConfig`](vec_inf/client/config.py) for details.
+* Check [vLLM Engine Arguments](https://docs.vllm.ai/en/stable/serving/engine_args.html) for the full list of available vLLM engine arguments, the default parallel size for any parallelization is default to 1, so none of the sizes were set specifically in this example
+* For GPU partitions with non-Ampere architectures, e.g. `rtx6000`, `t4v2`, BF16 isn't supported. For models that have BF16 as the default type, when using a non-Ampere GPU, use FP16 instead, i.e. `--dtype: float16`
+* Setting `--compilation-config` to `3` currently breaks multi-node model launches, so we don't set them for models that require multiple nodes of GPUs. 
 
 #### Other commands
 
@@ -161,7 +165,7 @@ Once the inference server is ready, you can start sending in inference requests.
     "prompt_logprobs":null
 }
 ```
-**NOTE**: For multimodal models, currently only `ChatCompletion` is available, and only one image can be provided for each prompt.
+**NOTE**: Certain models don't adhere to OpenAI's chat template, e.g. Mistral family. For these models, you can either change your prompt to follow the model's default chat template or provide your own chat template via `--chat-template: TEMPLATE_PATH`
 
 ## SSH tunnel from your local device
 If you want to run inference from your local device, you can open a SSH tunnel to your cluster environment like the following:

--- a/vec_inf/cli/_cli.py
+++ b/vec_inf/cli/_cli.py
@@ -73,6 +73,21 @@ def cli() -> None:
     help="Quality of service",
 )
 @click.option(
+    "--exclude",
+    type=str,
+    help="Exclude certain nodes from the resources granted to the job",
+)
+@click.option(
+    "--node-list",
+    type=str,
+    help="Request a specific list of nodes for deployment",
+)
+@click.option(
+    "--bind",
+    type=str,
+    help="Additional binds for the singularity container as a comma separated list of bind paths",
+)
+@click.option(
     "--time",
     type=str,
     help="Time limit for job, this should comply with QoS limits",
@@ -124,8 +139,16 @@ def launch(
             Number of nodes to use
         - gpus_per_node : int, optional
             Number of GPUs per node
+        - account : str, optional
+            Charge resources used by this job to specified account
         - qos : str, optional
             Quality of service tier
+        - exclude : str, optional
+            Exclude certain nodes from the resources granted to the job
+        - node_list : str, optional
+            Request a specific list of nodes for deployment
+        - bind : str, optional
+            Additional binds for the singularity container
         - time : str, optional
             Time limit for job
         - venv : str, optional

--- a/vec_inf/client/_client_vars.py
+++ b/vec_inf/client/_client_vars.py
@@ -129,6 +129,8 @@ class SlurmScriptTemplate(TypedDict):
         Commands for Singularity container setup
     imports : str
         Import statements and source commands
+    env_vars : list[str]
+        Environment variables to set
     singularity_command : str
         Template for Singularity execution command
     activate_venv : str
@@ -146,6 +148,7 @@ class SlurmScriptTemplate(TypedDict):
     shebang: ShebangConfig
     singularity_setup: list[str]
     imports: str
+    env_vars: list[str]
     singularity_command: str
     activate_venv: str
     server_setup: ServerSetupConfig

--- a/vec_inf/client/_client_vars.py
+++ b/vec_inf/client/_client_vars.py
@@ -222,8 +222,7 @@ SLURM_SCRIPT_TEMPLATE: SlurmScriptTemplate = {
         '    && mv temp.json "$json_path"',
     ],
     "launch_cmd": [
-        "vllm serve \\",
-        "    --model {model_weights_path} \\",
+        "vllm serve {model_weights_path} \\",
         "    --served-model-name {model_name} \\",
         '    --host "0.0.0.0" \\',
         "    --port $vllm_port_number \\",

--- a/vec_inf/client/_client_vars.py
+++ b/vec_inf/client/_client_vars.py
@@ -21,7 +21,12 @@ SLURM_JOB_CONFIG_ARGS : dict
 from pathlib import Path
 from typing import TypedDict
 
-from vec_inf.client.slurm_vars import SINGULARITY_LOAD_CMD
+from vec_inf.client.slurm_vars import (
+    LD_LIBRARY_PATH,
+    SINGULARITY_IMAGE,
+    SINGULARITY_LOAD_CMD,
+    VLLM_NCCL_SO_PATH,
+)
 
 
 MODEL_READY_SIGNATURE = "INFO:     Application startup complete."
@@ -152,10 +157,14 @@ SLURM_SCRIPT_TEMPLATE: SlurmScriptTemplate = {
     },
     "singularity_setup": [
         SINGULARITY_LOAD_CMD,
-        "singularity exec {singularity_image} ray stop",
+        f"singularity exec {SINGULARITY_IMAGE} ray stop",
     ],
     "imports": "source {src_dir}/find_port.sh",
-    "singularity_command": "singularity exec --nv --bind {model_weights_path}:{model_weights_path} --containall {singularity_image}",
+    "env_vars": [
+        f"export LD_LIBRARY_PATH={LD_LIBRARY_PATH}",
+        f"export VLLM_NCCL_SO_PATH={VLLM_NCCL_SO_PATH}",
+    ],
+    "singularity_command": f"singularity exec --nv --bind {{model_weights_path}}:{{model_weights_path}} --containall {SINGULARITY_IMAGE}",
     "activate_venv": "source {venv}/bin/activate",
     "server_setup": {
         "single_node": [

--- a/vec_inf/client/_client_vars.py
+++ b/vec_inf/client/_client_vars.py
@@ -166,7 +166,7 @@ SLURM_SCRIPT_TEMPLATE: SlurmScriptTemplate = {
         f"export LD_LIBRARY_PATH={LD_LIBRARY_PATH}",
         f"export VLLM_NCCL_SO_PATH={VLLM_NCCL_SO_PATH}",
     ],
-    "singularity_command": f"singularity exec --nv --bind {{model_weights_path}}:{{model_weights_path}}{{additional_binds}} --containall {SINGULARITY_IMAGE}",
+    "singularity_command": f"singularity exec --nv --bind {{model_weights_path}}{{additional_binds}} --containall {SINGULARITY_IMAGE}",
     "activate_venv": "source {venv}/bin/activate",
     "server_setup": {
         "single_node": [

--- a/vec_inf/client/_client_vars.py
+++ b/vec_inf/client/_client_vars.py
@@ -78,7 +78,12 @@ SLURM_JOB_CONFIG_ARGS = {
 VLLM_SHORT_TO_LONG_MAP = {
     "-tp": "--tensor-parallel-size",
     "-pp": "--pipeline-parallel-size",
+    "-dp": "--data-parallel-size",
+    "-dpl": "--data-parallel-size-local",
+    "-dpa": "--data-parallel-address",
+    "-dpp": "--data-parallel-rpc-port",
     "-O": "--compilation-config",
+    "-q": "--quantization",
 }
 
 
@@ -214,7 +219,7 @@ SLURM_SCRIPT_TEMPLATE: SlurmScriptTemplate = {
         '    && mv temp.json "$json_path"',
     ],
     "launch_cmd": [
-        "python3.10 -m vllm.entrypoints.openai.api_server \\",
+        "vllm serve \\",
         "    --model {model_weights_path} \\",
         "    --served-model-name {model_name} \\",
         '    --host "0.0.0.0" \\',

--- a/vec_inf/client/_client_vars.py
+++ b/vec_inf/client/_client_vars.py
@@ -65,6 +65,8 @@ SLURM_JOB_CONFIG_ARGS = {
     "qos": "qos",
     "time": "time",
     "nodes": "num_nodes",
+    "exclude": "exclude",
+    "nodelist": "node_list",
     "gpus-per-node": "gpus_per_node",
     "cpus-per-task": "cpus_per_task",
     "mem": "mem_per_node",
@@ -164,7 +166,7 @@ SLURM_SCRIPT_TEMPLATE: SlurmScriptTemplate = {
         f"export LD_LIBRARY_PATH={LD_LIBRARY_PATH}",
         f"export VLLM_NCCL_SO_PATH={VLLM_NCCL_SO_PATH}",
     ],
-    "singularity_command": f"singularity exec --nv --bind {{model_weights_path}}:{{model_weights_path}} --containall {SINGULARITY_IMAGE}",
+    "singularity_command": f"singularity exec --nv --bind {{model_weights_path}}:{{model_weights_path}}{{additional_binds}} --containall {SINGULARITY_IMAGE}",
     "activate_venv": "source {venv}/bin/activate",
     "server_setup": {
         "single_node": [

--- a/vec_inf/client/_helper.py
+++ b/vec_inf/client/_helper.py
@@ -5,7 +5,6 @@ metrics collection, and model registry operations.
 """
 
 import json
-import os
 import time
 import warnings
 from pathlib import Path

--- a/vec_inf/client/_helper.py
+++ b/vec_inf/client/_helper.py
@@ -36,10 +36,6 @@ from vec_inf.client.models import (
     ModelType,
     StatusResponse,
 )
-from vec_inf.client.slurm_vars import (
-    LD_LIBRARY_PATH,
-    VLLM_NCCL_SO_PATH,
-)
 
 
 class ModelLauncher:
@@ -230,11 +226,6 @@ class ModelLauncher:
 
         return params
 
-    def _set_env_vars(self) -> None:
-        """Set environment variables for the launch command."""
-        os.environ["LD_LIBRARY_PATH"] = LD_LIBRARY_PATH
-        os.environ["VLLM_NCCL_SO_PATH"] = VLLM_NCCL_SO_PATH
-
     def _build_launch_command(self) -> str:
         """Generate the slurm script and construct the launch command.
 
@@ -259,9 +250,6 @@ class ModelLauncher:
         SlurmJobError
             If SLURM job submission fails
         """
-        # Set environment variables
-        self._set_env_vars()
-
         # Build and execute the launch command
         command_output, stderr = utils.run_bash_command(self._build_launch_command())
 

--- a/vec_inf/client/_slurm_script_generator.py
+++ b/vec_inf/client/_slurm_script_generator.py
@@ -39,6 +39,9 @@ class SlurmScriptGenerator:
         self.params = params
         self.is_multinode = int(self.params["num_nodes"]) > 1
         self.use_singularity = self.params["venv"] == "singularity"
+        self.additional_binds = self.params.get("binds", "")
+        if self.additional_binds:
+            self.additional_binds = f" --bind {self.additional_binds}"
         self.model_weights_path = str(
             Path(params["model_weights_parent_dir"], params["model_name"])
         )
@@ -104,6 +107,7 @@ class SlurmScriptGenerator:
                     "SINGULARITY_PLACEHOLDER",
                     SLURM_SCRIPT_TEMPLATE["singularity_command"].format(
                         model_weights_path=self.model_weights_path,
+                        additional_binds=self.additional_binds,
                     ),
                 )
         else:
@@ -135,6 +139,7 @@ class SlurmScriptGenerator:
             launcher_script.append(
                 SLURM_SCRIPT_TEMPLATE["singularity_command"].format(
                     model_weights_path=self.model_weights_path,
+                    additional_binds=self.additional_binds,
                 )
                 + " \\"
             )

--- a/vec_inf/client/_slurm_script_generator.py
+++ b/vec_inf/client/_slurm_script_generator.py
@@ -89,12 +89,8 @@ class SlurmScriptGenerator:
         """
         server_script = ["\n"]
         if self.use_singularity:
-            server_script.append(
-                "\n".join(SLURM_SCRIPT_TEMPLATE["singularity_setup"])
-            )
-        server_script.append(
-            "\n".join(SLURM_SCRIPT_TEMPLATE["env_vars"])
-        )
+            server_script.append("\n".join(SLURM_SCRIPT_TEMPLATE["singularity_setup"]))
+        server_script.append("\n".join(SLURM_SCRIPT_TEMPLATE["env_vars"]))
         server_script.append(
             SLURM_SCRIPT_TEMPLATE["imports"].format(src_dir=self.params["src_dir"])
         )

--- a/vec_inf/client/_slurm_script_generator.py
+++ b/vec_inf/client/_slurm_script_generator.py
@@ -12,7 +12,6 @@ from vec_inf.client._client_vars import (
     SLURM_JOB_CONFIG_ARGS,
     SLURM_SCRIPT_TEMPLATE,
 )
-from vec_inf.client.slurm_vars import SINGULARITY_IMAGE
 
 
 class SlurmScriptGenerator:
@@ -88,10 +87,11 @@ class SlurmScriptGenerator:
         server_script = ["\n"]
         if self.use_singularity:
             server_script.append(
-                "\n".join(SLURM_SCRIPT_TEMPLATE["singularity_setup"]).format(
-                    singularity_image=SINGULARITY_IMAGE,
-                )
+                "\n".join(SLURM_SCRIPT_TEMPLATE["singularity_setup"])
             )
+        server_script.append(
+            "\n".join(SLURM_SCRIPT_TEMPLATE["env_vars"])
+        )
         server_script.append(
             SLURM_SCRIPT_TEMPLATE["imports"].format(src_dir=self.params["src_dir"])
         )
@@ -104,7 +104,6 @@ class SlurmScriptGenerator:
                     "SINGULARITY_PLACEHOLDER",
                     SLURM_SCRIPT_TEMPLATE["singularity_command"].format(
                         model_weights_path=self.model_weights_path,
-                        singularity_image=SINGULARITY_IMAGE,
                     ),
                 )
         else:
@@ -136,7 +135,6 @@ class SlurmScriptGenerator:
             launcher_script.append(
                 SLURM_SCRIPT_TEMPLATE["singularity_command"].format(
                     model_weights_path=self.model_weights_path,
-                    singularity_image=SINGULARITY_IMAGE,
                 )
                 + " \\"
             )

--- a/vec_inf/client/_slurm_script_generator.py
+++ b/vec_inf/client/_slurm_script_generator.py
@@ -39,7 +39,7 @@ class SlurmScriptGenerator:
         self.params = params
         self.is_multinode = int(self.params["num_nodes"]) > 1
         self.use_singularity = self.params["venv"] == "singularity"
-        self.additional_binds = self.params.get("binds", "")
+        self.additional_binds = self.params.get("bind", "")
         if self.additional_binds:
             self.additional_binds = f" --bind {self.additional_binds}"
         self.model_weights_path = str(

--- a/vec_inf/client/config.py
+++ b/vec_inf/client/config.py
@@ -114,7 +114,7 @@ class ModelConfig(BaseModel):
     node_list: Optional[str] = Field(
         default=None, description="Request a specific list of nodes for deployment"
     )
-    binds: Optional[str] = Field(
+    bind: Optional[str] = Field(
         default=None, description="Additional binds for the singularity container"
     )
     venv: str = Field(

--- a/vec_inf/client/config.py
+++ b/vec_inf/client/config.py
@@ -108,6 +108,15 @@ class ModelConfig(BaseModel):
     partition: Union[PARTITION, str] = Field(
         default=cast(str, DEFAULT_ARGS["partition"]), description="GPU partition type"
     )
+    exclude: Optional[str] = Field(
+        default=None, description="Exclude certain nodes from the resources granted to the job"
+    )
+    node_list: Optional[str] = Field(
+        default=None, description="Request a specific list of nodes for deployment"
+    )
+    binds: Optional[str] = Field(
+        default=None, description="Additional binds for the singularity container"
+    )
     venv: str = Field(
         default="singularity", description="Virtual environment/container system"
     )

--- a/vec_inf/client/config.py
+++ b/vec_inf/client/config.py
@@ -109,7 +109,8 @@ class ModelConfig(BaseModel):
         default=cast(str, DEFAULT_ARGS["partition"]), description="GPU partition type"
     )
     exclude: Optional[str] = Field(
-        default=None, description="Exclude certain nodes from the resources granted to the job"
+        default=None,
+        description="Exclude certain nodes from the resources granted to the job",
     )
     node_list: Optional[str] = Field(
         default=None, description="Request a specific list of nodes for deployment"

--- a/vec_inf/client/models.py
+++ b/vec_inf/client/models.py
@@ -170,6 +170,12 @@ class LaunchOptions:
         Quality of Service level
     time : str, optional
         Time limit for the job
+    exclude : str, optional
+        Exclude certain nodes from the resources granted to the job
+    node_list : str, optional
+        Request a specific list of nodes for deployment
+    bind : str, optional
+        Additional binds for the singularity container
     vocab_size : int, optional
         Size of model vocabulary
     data_type : str, optional
@@ -191,6 +197,9 @@ class LaunchOptions:
     gpus_per_node: Optional[int] = None
     account: Optional[str] = None
     qos: Optional[str] = None
+    exclude: Optional[str] = None
+    node_list: Optional[str] = None
+    bind: Optional[str] = None
     time: Optional[str] = None
     vocab_size: Optional[int] = None
     data_type: Optional[str] = None

--- a/vec_inf/config/models.yaml
+++ b/vec_inf/config/models.yaml
@@ -14,7 +14,6 @@ models:
       --tensor-parallel-size: 4
       --max-model-len: 8192
       --max-num-seqs: 256
-      --compilation-config: 3
   c4ai-command-r-plus-08-2024:
     model_family: c4ai-command-r
     model_variant: plus-08-2024
@@ -30,7 +29,6 @@ models:
       --tensor-parallel-size: 4
       --max-model-len: 65536
       --max-num-seqs: 256
-      --compilation-config: 3
   c4ai-command-r-08-2024:
     model_family: c4ai-command-r
     model_variant: 08-2024
@@ -494,7 +492,6 @@ models:
       --tensor-parallel-size: 4
       --max-model-len: 16384
       --max-num-seqs: 256
-      --compilation-config: 3
   Mistral-7B-Instruct-v0.1:
     model_family: Mistral
     model_variant: 7B-Instruct-v0.1
@@ -566,7 +563,6 @@ models:
       --tensor-parallel-size: 4
       --max-model-len: 32768
       --max-num-seqs: 256
-      --compilation-config: 3
   Mistral-Large-Instruct-2411:
     model_family: Mistral
     model_variant: Large-Instruct-2411
@@ -582,7 +578,6 @@ models:
       --tensor-parallel-size: 4
       --max-model-len: 32768
       --max-num-seqs: 256
-      --compilation-config: 3
   Mixtral-8x7B-Instruct-v0.1:
     model_family: Mixtral
     model_variant: 8x7B-Instruct-v0.1
@@ -613,7 +608,6 @@ models:
       --tensor-parallel-size: 4
       --max-model-len: 65536
       --max-num-seqs: 256
-      --compilation-config: 3
   Mixtral-8x22B-Instruct-v0.1:
     model_family: Mixtral
     model_variant: 8x22B-Instruct-v0.1
@@ -629,7 +623,6 @@ models:
       --tensor-parallel-size: 4
       --max-model-len: 65536
       --max-num-seqs: 256
-      --compilation-config: 3
   Phi-3-medium-128k-instruct:
     model_family: Phi-3
     model_variant: medium-128k-instruct


### PR DESCRIPTION
# PR Type
[Feature|Fix]

# Short Description
Misc small features added and bug fixes:

- Fixed multi-node launch GPU placement group issue: `--exclusive` option is needed for slurm script and compilation config needs to stay at 0
- Set environment variables in the generated slurm script instead of in the helper to ensure reusability
- Replaced `python3.10 -m vllm.entrypoints.openai.api_server` with `vllm serve` to support custom chat template usage
- Added additional launch options: `--exclude` for excluding certain nodes, `--node-list` for targeting a specific list of nodes, and `--bind` for binding additional directories
- Added remaining vLLM engine arg short-long name mappings for robustness
- Added some notes in README to capture some gotchas

