### PR TITLE
Fix json format

### DIFF
--- a/tests/vec_inf/cli/test_helper.py
+++ b/tests/vec_inf/cli/test_helper.py
@@ -1,5 +1,6 @@
 """Tests for the CLI helper classes."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from rich.console import Console
@@ -218,10 +219,11 @@ class TestStatusResponseFormatter:
         formatter.output_json()
 
         mock_echo.assert_called_once()
-        # Just check that it was called with a dict
+        # Just check that it was called with a json compatible string
         output = mock_echo.call_args[0][0]
-        assert isinstance(output, dict)
-        assert "model_name" in output
+        json_dict = json.loads(output)
+        assert isinstance(json_dict, dict)
+        assert "model_name" in json_dict
 
     @patch("click.echo")
     def test_output_json_with_error_reasons(self, mock_echo):
@@ -242,9 +244,10 @@ class TestStatusResponseFormatter:
 
         mock_echo.assert_called_once()
         output = mock_echo.call_args[0][0]
-        assert isinstance(output, dict)
-        assert "pending_reason" in output
-        assert "failed_reason" in output
+        json_dict = json.loads(output)
+        assert isinstance(json_dict, dict)
+        assert "pending_reason" in json_dict
+        assert "failed_reason" in json_dict
 
 
 class TestMetricsResponseFormatter:

--- a/vec_inf/cli/_helper.py
+++ b/vec_inf/cli/_helper.py
@@ -4,6 +4,7 @@ This module provides formatting and display classes for the command-line interfa
 handling the presentation of model information, status updates, and metrics.
 """
 
+import json
 from pathlib import Path
 from typing import Any, Union
 
@@ -27,9 +28,7 @@ class LaunchResponseFormatter:
     Parameters
     ----------
     model_name : str
-        Name of the launched model
-    params : dict[str, Any]
-        Launch parameters and configuration
+        Name of the launched model    params : dict[str, Any] Launch parameters and configuration
     """
 
     def __init__(self, model_name: str, params: dict[str, Any]):
@@ -116,28 +115,14 @@ class BatchLaunchResponseFormatter:
         for model_name in self.params["models"]:
             table.add_row("Model Name", model_name, style="magenta")
             # Add resource allocation details
-            table.add_row(
-                "Partition", f"  {self.params['models'][model_name]['partition']}"
-            )
+            table.add_row("Partition", f"  {self.params['models'][model_name]['partition']}")
             table.add_row("QoS", f"  {self.params['models'][model_name]['qos']}")
-            table.add_row(
-                "Time Limit", f"  {self.params['models'][model_name]['time']}"
-            )
-            table.add_row(
-                "Num Nodes", f"  {self.params['models'][model_name]['num_nodes']}"
-            )
-            table.add_row(
-                "GPUs/Node", f"  {self.params['models'][model_name]['gpus_per_node']}"
-            )
-            table.add_row(
-                "CPUs/Task", f"  {self.params['models'][model_name]['cpus_per_task']}"
-            )
-            table.add_row(
-                "Memory/Node", f"  {self.params['models'][model_name]['mem_per_node']}"
-            )
-            table.add_row(
-                "Log Directory", f"  {self.params['models'][model_name]['log_dir']}"
-            )
+            table.add_row("Time Limit", f"  {self.params['models'][model_name]['time']}")
+            table.add_row("Num Nodes", f"  {self.params['models'][model_name]['num_nodes']}")
+            table.add_row("GPUs/Node", f"  {self.params['models'][model_name]['gpus_per_node']}")
+            table.add_row("CPUs/Task", f"  {self.params['models'][model_name]['cpus_per_task']}")
+            table.add_row("Memory/Node", f"  {self.params['models'][model_name]['mem_per_node']}")
+            table.add_row("Log Directory", f"  {self.params['models'][model_name]['log_dir']}")
 
         return table
 
@@ -176,7 +161,12 @@ class StatusResponseFormatter:
             json_data["pending_reason"] = self.status_info.pending_reason
         if self.status_info.failed_reason:
             json_data["failed_reason"] = self.status_info.failed_reason
-        click.echo(json_data)
+
+        # Convert dict to json compliant string with double quotes
+        json_string = json.dumps(json_data)
+
+        # Output json to console
+        click.echo(json_string)
 
     def output_table(self) -> Table:
         """Create and display rich table.
@@ -352,9 +342,7 @@ class ListCmdDisplay:
         self.model_config = None
         self.model_names: list[str] = []
 
-    def _format_single_model_output(
-        self, config: ModelConfig
-    ) -> Union[dict[str, Any], Table]:
+    def _format_single_model_output(self, config: ModelConfig) -> Union[dict[str, Any], Table]:
         """Format output table for a single model.
 
         Parameters
@@ -372,9 +360,7 @@ class ListCmdDisplay:
             excluded = {"venv", "log_dir"}
             config_dict = config.model_dump(exclude=excluded)
             # Convert Path objects to strings
-            config_dict["model_weights_parent_dir"] = str(
-                config_dict["model_weights_parent_dir"]
-            )
+            config_dict["model_weights_parent_dir"] = str(config_dict["model_weights_parent_dir"])
             return config_dict
 
         table = create_table(key_title="Model Config", value_title="Value")
@@ -387,9 +373,7 @@ class ListCmdDisplay:
                     table.add_row(f"  {vllm_arg}:", str(vllm_value))
         return table
 
-    def _format_all_models_output(
-        self, model_infos: list[ModelInfo]
-    ) -> Union[list[str], list[Panel]]:
+    def _format_all_models_output(self, model_infos: list[ModelInfo]) -> Union[list[str], list[Panel]]:
         """Format output table for all models.
 
         Parameters

--- a/vec_inf/cli/_helper.py
+++ b/vec_inf/cli/_helper.py
@@ -28,7 +28,8 @@ class LaunchResponseFormatter:
     Parameters
     ----------
     model_name : str
-        Name of the launched model    params : dict[str, Any] Launch parameters and configuration
+        Name of the launched model    params : dict[str, Any] Launch parameters and
+            configuration
     """
 
     def __init__(self, model_name: str, params: dict[str, Any]):
@@ -115,14 +116,28 @@ class BatchLaunchResponseFormatter:
         for model_name in self.params["models"]:
             table.add_row("Model Name", model_name, style="magenta")
             # Add resource allocation details
-            table.add_row("Partition", f"  {self.params['models'][model_name]['partition']}")
+            table.add_row(
+                "Partition", f"  {self.params['models'][model_name]['partition']}"
+            )
             table.add_row("QoS", f"  {self.params['models'][model_name]['qos']}")
-            table.add_row("Time Limit", f"  {self.params['models'][model_name]['time']}")
-            table.add_row("Num Nodes", f"  {self.params['models'][model_name]['num_nodes']}")
-            table.add_row("GPUs/Node", f"  {self.params['models'][model_name]['gpus_per_node']}")
-            table.add_row("CPUs/Task", f"  {self.params['models'][model_name]['cpus_per_task']}")
-            table.add_row("Memory/Node", f"  {self.params['models'][model_name]['mem_per_node']}")
-            table.add_row("Log Directory", f"  {self.params['models'][model_name]['log_dir']}")
+            table.add_row(
+                "Time Limit", f"  {self.params['models'][model_name]['time']}"
+            )
+            table.add_row(
+                "Num Nodes", f"  {self.params['models'][model_name]['num_nodes']}"
+            )
+            table.add_row(
+                "GPUs/Node", f"  {self.params['models'][model_name]['gpus_per_node']}"
+            )
+            table.add_row(
+                "CPUs/Task", f"  {self.params['models'][model_name]['cpus_per_task']}"
+            )
+            table.add_row(
+                "Memory/Node", f"  {self.params['models'][model_name]['mem_per_node']}"
+            )
+            table.add_row(
+                "Log Directory", f"  {self.params['models'][model_name]['log_dir']}"
+            )
 
         return table
 
@@ -342,7 +357,9 @@ class ListCmdDisplay:
         self.model_config = None
         self.model_names: list[str] = []
 
-    def _format_single_model_output(self, config: ModelConfig) -> Union[dict[str, Any], Table]:
+    def _format_single_model_output(
+        self, config: ModelConfig
+    ) -> Union[dict[str, Any], Table]:
         """Format output table for a single model.
 
         Parameters
@@ -360,7 +377,9 @@ class ListCmdDisplay:
             excluded = {"venv", "log_dir"}
             config_dict = config.model_dump(exclude=excluded)
             # Convert Path objects to strings
-            config_dict["model_weights_parent_dir"] = str(config_dict["model_weights_parent_dir"])
+            config_dict["model_weights_parent_dir"] = str(
+                config_dict["model_weights_parent_dir"]
+            )
             return config_dict
 
         table = create_table(key_title="Model Config", value_title="Value")
@@ -373,7 +392,9 @@ class ListCmdDisplay:
                     table.add_row(f"  {vllm_arg}:", str(vllm_value))
         return table
 
-    def _format_all_models_output(self, model_infos: list[ModelInfo]) -> Union[list[str], list[Panel]]:
+    def _format_all_models_output(
+        self, model_infos: list[ModelInfo]
+    ) -> Union[list[str], list[Panel]]:
         """Format output table for all models.
 
         Parameters


### PR DESCRIPTION
# PR Type
[Feature | **Fix** | Documentation | Other() ]

# Short Description
The `--json-mode` flag of the `vec-inf status` command was outputting string literals with single quotes, which is not compatible with json which requires double quotes. This fixes that issue ensuring output is json compliant.

# Tests Added
Fixed two tests that were asserting that input to click.echo was a dict, now they assert that input is a json compatible string that can be converted to a dictionary using json.loads.
