### PR TITLE
pip index pointed to cuda121 instead of 126

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /vec-inf
 COPY . /vec-inf
 
 # Install project dependencies with build requirements
-RUN PIP_INDEX_URL="https://download.pytorch.org/whl/cu121" uv pip install --system -e .[dev]
+RUN PIP_INDEX_URL="https://download.pytorch.org/whl/cu126" uv pip install --system -e .[dev]
 
 # Final configuration
 RUN mkdir -p /vec-inf/nccl && \


### PR DESCRIPTION
# PR Type
[Feature | **Fix** | Documentation | Other() ]

Idk if this fixes anything but noticed the base image used cuda126 but the pip index was pulling pytorch from cuda121. If this is intentional just close the PR.
