### PR TITLE
Adjust docker workflow to run on self-hosted VM

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,9 @@ jobs:
           VERSION=$(grep -A 1 'name = "vllm"' uv.lock | grep version | cut -d '"' -f 2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration for Docker builds. The runner environment for the `push_to_registry` job has been switched from GitHub-hosted (`ubuntu-latest`) to a self-hosted runner with Docker capabilities.