### PR TITLE
Update container cache dir binding

### DIFF
--- a/vec_inf/config/environment.yaml
+++ b/vec_inf/config/environment.yaml
@@ -35,7 +35,7 @@ default_args:
   resource_type: "l40s"
   exclude: ""
   nodelist: ""
-  bind: ""
+  bind: "$SLURM_TMPDIR:$HOME/.cache"
   venv: "apptainer"
   data_type: "auto"
   log_dir: "~/.vec-inf-logs"


### PR DESCRIPTION
# PR Type
[Feature]

# Short Description
Currently `vec-inf` creates a `.vec-inf-cache` folder to be binded to the `.cache` directory inside the container. For Slurm cluster that has the environment variable `SLURM_TMPDIR` enabled, we should take advantage of this as it gets cleaned up automatically on job exit, removing the user's responsibility to monitor the generated cache directory. This addresses #198 