### PR TITLE
Small Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,22 @@ For more details on the usage of these commands, refer to the [User Guide](https
 Example:
 
 ```python
->>> from vec_inf.api import VecInfClient
->>> client = VecInfClient()
->>> # Assume VEC_INF_ACCOUNT and VEC_INF_WORK_DIR is set
->>> response = client.launch_model("Meta-Llama-3.1-8B-Instruct")
->>> job_id = response.slurm_job_id
->>> status = client.get_status(job_id)
->>> if status.status == ModelStatus.READY:
-...     print(f"Model is ready at {status.base_url}")
->>> # Alternatively, use wait_until_ready which will either return a StatusResponse or throw a ServerError
->>> try:
->>>     status = wait_until_ready(job_id)
->>> except ServerError as e:
->>>     print(f"Model launch failed: {e}")
->>> client.shutdown_model(job_id)
+from vec_inf.client import VecInfClient
+from vec_inf.client.models import ModelStatus
+
+client = VecInfClient()
+# Assume VEC_INF_ACCOUNT and VEC_INF_WORK_DIR is set
+response = client.launch_model("Meta-Llama-3.1-8B-Instruct")
+job_id = response.slurm_job_id
+status = client.get_status(job_id)
+if status.status == ModelStatus.READY:
+    print(f"Model is ready at {status.base_url}")
+# Alternatively, use wait_until_ready which will either return a StatusResponse or throw a ServerError
+try:
+    status = wait_until_ready(job_id)
+    except ServerError as e:
+    print(f"Model launch failed: {e}")
+client.shutdown_model(job_id)
 ```
 
 For details on the usage of the API, refer to the [API Reference](https://vectorinstitute.github.io/vector-inference/api/)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For more details on the usage of these commands, refer to the [User Guide](https
 Example:
 
 ```python
-from vec_inf.client import VecInfClient
+ffrom vec_inf.client import VecInfClient
 from vec_inf.client.models import ModelStatus
 
 client = VecInfClient()
@@ -73,13 +73,8 @@ client = VecInfClient()
 response = client.launch_model("Meta-Llama-3.1-8B-Instruct")
 job_id = response.slurm_job_id
 status = client.get_status(job_id)
-if status.status == ModelStatus.READY:
+if status == ModelStatus.READY:
     print(f"Model is ready at {status.base_url}")
-# Alternatively, use wait_until_ready which will either return a StatusResponse or throw a ServerError
-try:
-    status = wait_until_ready(job_id)
-    except ServerError as e:
-    print(f"Model launch failed: {e}")
 client.shutdown_model(job_id)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,30 @@
 # Vector Inference: Easy inference on Slurm clusters
 
----
+----------------------------------------------------
 
-[PyPI](https://pypi.org/project/vec-inf)
-[downloads](https://pypistats.org/packages/vec-inf)
-[code checks](https://github.com/VectorInstitute/vector-inference/actions/workflows/code_checks.yml)
-[docs](https://github.com/VectorInstitute/vector-inference/actions/workflows/docs.yml)
-[codecov](https://app.codecov.io/github/VectorInstitute/vector-inference/tree/main)
-[vLLM](https://docs.vllm.ai/en/v0.19.0/)
-[SGLang](https://docs.sglang.io/index.html)
-GitHub License
+[![PyPI](https://img.shields.io/pypi/v/vec-inf)](https://pypi.org/project/vec-inf)
+[![downloads](https://img.shields.io/pypi/dm/vec-inf)](https://pypistats.org/packages/vec-inf)
+[![code checks](https://github.com/VectorInstitute/vector-inference/actions/workflows/code_checks.yml/badge.svg)](https://github.com/VectorInstitute/vector-inference/actions/workflows/code_checks.yml)
+[![docs](https://github.com/VectorInstitute/vector-inference/actions/workflows/docs.yml/badge.svg)](https://github.com/VectorInstitute/vector-inference/actions/workflows/docs.yml)
+[![codecov](https://codecov.io/github/VectorInstitute/vector-inference/branch/main/graph/badge.svg?token=NI88QSIGAC)](https://app.codecov.io/github/VectorInstitute/vector-inference/tree/main)
+[![vLLM](https://img.shields.io/badge/vLLM-0.19.0-blue)](https://docs.vllm.ai/en/v0.19.0/)
+[![SGLang](https://img.shields.io/badge/SGLang-0.5.9-blue)](https://docs.sglang.io/index.html)
+![GitHub License](https://img.shields.io/github/license/VectorInstitute/vector-inference)
 
 This repository provides an easy-to-use solution to run inference servers on [Slurm](https://slurm.schedmd.com/overview.html)-managed computing clusters using open-source inference engines ([vLLM](https://docs.vllm.ai/en/v0.19.0/), [SGLang](https://docs.sglang.io/index.html)). **This package runs natively on the Vector Institute cluster environments**. To adapt to other environments, follow the instructions in [Installation](#installation).
 
 ## Installation
-
 If you are using the Vector cluster environment, and you don't need any customization to the inference server environment, run the following to install package:
 
 ```bash
 pip install vec-inf
 ```
-
-Otherwise, we recommend using the provided `[vllm.Dockerfile](vllm.Dockerfile)` and `[sglang.Dockerfile](sglang.Dockerfile)` to set up your own environment with the package. The built images are available through [Docker Hub](https://hub.docker.com/orgs/vectorinstitute/repositories)
+Otherwise, we recommend using the provided [`vllm.Dockerfile`](vllm.Dockerfile) and [`sglang.Dockerfile`](sglang.Dockerfile) to set up your own environment with the package. The built images are available through [Docker Hub](https://hub.docker.com/orgs/vectorinstitute/repositories)
 
 If you'd like to use `vec-inf` on your own Slurm cluster, you would need to update the configuration files, there are 3 ways to do it:
-
-- Clone the repository and update the `environment.yaml` and the `models.yaml` file in `[vec_inf/config](vec_inf/config/)`, then install from source by running `pip install .`.
-- The package would try to look for cached configuration files in your environment before using the default configuration. The default cached configuration directory path points to `/model-weights/vec-inf-shared`, you would need to create an `environment.yaml` and a `models.yaml` following the format of these files in `[vec_inf/config](vec_inf/config/)`.
-- [OPTIONAL] The package could also look for an enviroment variable `VEC_INF_CONFIG_DIR`. You can put your `environment.yaml` and `models.yaml` in a directory of your choice and set the enviroment variable `VEC_INF_CONFIG_DIR` to point to that location.
+* Clone the repository and update the `environment.yaml` and the `models.yaml` file in [`vec_inf/config`](vec_inf/config/), then install from source by running `pip install .`.
+* The package would try to look for cached configuration files in your environment before using the default configuration. The default cached configuration directory path points to `/model-weights/vec-inf-shared`, you would need to create an `environment.yaml` and a `models.yaml` following the format of these files in [`vec_inf/config`](vec_inf/config/).
+* [OPTIONAL] The package could also look for an enviroment variable `VEC_INF_CONFIG_DIR`. You can put your `environment.yaml` and `models.yaml` in a directory of your choice and set the enviroment variable `VEC_INF_CONFIG_DIR` to point to that location.
 
 ## Usage
 
@@ -42,26 +39,24 @@ We will use the Llama 3.1 model as example, to launch an OpenAI compatible infer
 ```bash
 vec-inf launch Meta-Llama-3.1-8B-Instruct
 ```
-
 You should see an output like the following:
 
-
+<img width="720" alt="launch_image" src="./docs/assets/launch.png" />
 
 **NOTE**: You can set the required fields in the environment configuration (`environment.yaml`), it's a mapping between required arguments and their corresponding environment variables. On the Vector **Killarney** Cluster environment, the required fields are:
+  * `--account`, `-A`: The Slurm account, this argument can be set to default by setting environment variable `VEC_INF_ACCOUNT`.
+  * `--work-dir`, `-D`: A working directory other than your home directory, this argument can be set to default by seeting environment variable `VEC_INF_WORK_DIR`.
 
-- `--account`, `-A`: The Slurm account, this argument can be set to default by setting environment variable `VEC_INF_ACCOUNT`.
-- `--work-dir`, `-D`: A working directory other than your home directory, this argument can be set to default by seeting environment variable `VEC_INF_WORK_DIR`.
-
-Models that are already supported by `vec-inf` would be launched using the cached configuration (set in [slurm_vars.py](vec_inf/client/slurm_vars.py)) or [default configuration](vec_inf/config/models.yaml). You can override these values by providing additional parameters. Use `vec-inf launch --help` to see the full list of parameters that can be overriden. You can also launch your own custom model as long as the model architecture is supported by the underlying inference engine. For detailed instructions on how to customize your model launch, check out the `[launch` command section in User Guide](https://vectorinstitute.github.io/vector-inference/latest/user_guide/#launch-command). During the launch process, relevant log files and scripts will be written to a log directory (default to `.vec-inf-logs` in your home directory), and a cache directory (`.vec-inf-cache`) will be created in your working directory (defaults to your home directory if not specified or required) for torch compile cache.
+Models that are already supported by `vec-inf` would be launched using the cached configuration (set in [slurm_vars.py](vec_inf/client/slurm_vars.py)) or [default configuration](vec_inf/config/models.yaml). You can override these values by providing additional parameters. Use `vec-inf launch --help` to see the full list of parameters that can be overriden. You can also launch your own custom model as long as the model architecture is supported by the underlying inference engine. For detailed instructions on how to customize your model launch, check out the [`launch` command section in User Guide](https://vectorinstitute.github.io/vector-inference/latest/user_guide/#launch-command). During the launch process, relevant log files and scripts will be written to a log directory (default to `.vec-inf-logs` in your home directory), and a cache directory (`.vec-inf-cache`) will be created in your working directory (defaults to your home directory if not specified or required) for torch compile cache.
 
 #### Other commands
 
-- `batch-launch`: Launch multiple model inference servers at once, currently ONLY single node models supported,
-- `status`: Check the status of all `vec-inf` jobs, or a specific job by providing its job ID.
-- `metrics`: Streams performance metrics to the console.
-- `shutdown`: Shutdown a model by providing its Slurm job ID.
-- `list`: List all available model names, or view the default/cached configuration of a specific model.
-- `cleanup`: Remove old log directories, use `--help` to see the supported filters. Use `--dry-run` to preview what would be deleted.
+* `batch-launch`: Launch multiple model inference servers at once, currently ONLY single node models supported,
+* `status`: Check the status of all `vec-inf` jobs, or a specific job by providing its job ID.
+* `metrics`: Streams performance metrics to the console.
+* `shutdown`: Shutdown a model by providing its Slurm job ID.
+* `list`: List all available model names, or view the default/cached configuration of a specific model.
+* `cleanup`: Remove old log directories, use `--help` to see the supported filters. Use `--dry-run` to preview what would be deleted.
 
 For more details on the usage of these commands, refer to the [User Guide](https://vectorinstitute.github.io/vector-inference/user_guide/)
 
@@ -78,8 +73,13 @@ client = VecInfClient()
 response = client.launch_model("Meta-Llama-3.1-8B-Instruct")
 job_id = response.slurm_job_id
 status = client.get_status(job_id)
-if status == ModelStatus.READY:
+if status.status == ModelStatus.READY:
     print(f"Model is ready at {status.base_url}")
+# Alternatively, use wait_until_ready which will either return a StatusResponse or throw a ServerError
+try:
+    status = wait_until_ready(job_id)
+    except ServerError as e:
+    print(f"Model launch failed: {e}")
 client.shutdown_model(job_id)
 ```
 
@@ -91,7 +91,7 @@ With every model launch, a Slurm script will be generated dynamically based on t
 
 ## Send inference requests
 
-Once the inference server is ready, you can start sending in inference requests. We provide example scripts for sending inference requests in `[examples](examples)` folder. Make sure to update the model server URL and the model weights location in the scripts. For example, you can run `python examples/inference/llm/chat_completions.py`, and you should expect to see an output like the following:
+Once the inference server is ready, you can start sending in inference requests. We provide example scripts for sending inference requests in [`examples`](examples) folder. Make sure to update the model server URL and the model weights location in the scripts. For example, you can run `python examples/inference/llm/chat_completions.py`, and you should expect to see an output like the following:
 
 ```json
 {
@@ -125,23 +125,17 @@ Once the inference server is ready, you can start sending in inference requests.
 }
 
 ```
-
 **NOTE**: Certain models don't adhere to OpenAI's chat template, e.g. Mistral family. For these models, you can either change your prompt to follow the model's default chat template or provide your own chat template via `--chat-template: TEMPLATE_PATH`.
 
 ## SSH tunnel from your local device
-
 If you want to run inference from your local device, you can open a SSH tunnel to your cluster environment like the following:
-
 ```bash
 ssh -L 8081:10.1.1.29:8081 username@v.vectorinstitute.ai -N
 ```
-
 The example provided above is for the Vector Killarney cluster, change the variables accordingly for your environment. The IP address for the compute nodes on Killarney follow `10.1.1.XX` pattern, where `XX` is the GPU number (`kn029` -> `29` in this example).
 
 ## Reference
-
 If you found Vector Inference useful in your research or applications, please cite using the following BibTeX template:
-
 ```
 @software{vector_inference,
   title        = {Vector Inference: Efficient LLM inference on Slurm clusters},
@@ -152,4 +146,3 @@ If you found Vector Inference useful in your research or applications, please ci
   url          = {https://github.com/VectorInstitute/vector-inference}
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,30 +1,33 @@
 # Vector Inference: Easy inference on Slurm clusters
 
-----------------------------------------------------
+---
 
-[![PyPI](https://img.shields.io/pypi/v/vec-inf)](https://pypi.org/project/vec-inf)
-[![downloads](https://img.shields.io/pypi/dm/vec-inf)](https://pypistats.org/packages/vec-inf)
-[![code checks](https://github.com/VectorInstitute/vector-inference/actions/workflows/code_checks.yml/badge.svg)](https://github.com/VectorInstitute/vector-inference/actions/workflows/code_checks.yml)
-[![docs](https://github.com/VectorInstitute/vector-inference/actions/workflows/docs.yml/badge.svg)](https://github.com/VectorInstitute/vector-inference/actions/workflows/docs.yml)
-[![codecov](https://codecov.io/github/VectorInstitute/vector-inference/branch/main/graph/badge.svg?token=NI88QSIGAC)](https://app.codecov.io/github/VectorInstitute/vector-inference/tree/main)
-[![vLLM](https://img.shields.io/badge/vLLM-0.19.0-blue)](https://docs.vllm.ai/en/v0.19.0/)
-[![SGLang](https://img.shields.io/badge/SGLang-0.5.9-blue)](https://docs.sglang.io/index.html)
-![GitHub License](https://img.shields.io/github/license/VectorInstitute/vector-inference)
+[PyPI](https://pypi.org/project/vec-inf)
+[downloads](https://pypistats.org/packages/vec-inf)
+[code checks](https://github.com/VectorInstitute/vector-inference/actions/workflows/code_checks.yml)
+[docs](https://github.com/VectorInstitute/vector-inference/actions/workflows/docs.yml)
+[codecov](https://app.codecov.io/github/VectorInstitute/vector-inference/tree/main)
+[vLLM](https://docs.vllm.ai/en/v0.19.0/)
+[SGLang](https://docs.sglang.io/index.html)
+GitHub License
 
 This repository provides an easy-to-use solution to run inference servers on [Slurm](https://slurm.schedmd.com/overview.html)-managed computing clusters using open-source inference engines ([vLLM](https://docs.vllm.ai/en/v0.19.0/), [SGLang](https://docs.sglang.io/index.html)). **This package runs natively on the Vector Institute cluster environments**. To adapt to other environments, follow the instructions in [Installation](#installation).
 
 ## Installation
+
 If you are using the Vector cluster environment, and you don't need any customization to the inference server environment, run the following to install package:
 
 ```bash
 pip install vec-inf
 ```
-Otherwise, we recommend using the provided [`vllm.Dockerfile`](vllm.Dockerfile) and [`sglang.Dockerfile`](sglang.Dockerfile) to set up your own environment with the package. The built images are available through [Docker Hub](https://hub.docker.com/orgs/vectorinstitute/repositories)
+
+Otherwise, we recommend using the provided `[vllm.Dockerfile](vllm.Dockerfile)` and `[sglang.Dockerfile](sglang.Dockerfile)` to set up your own environment with the package. The built images are available through [Docker Hub](https://hub.docker.com/orgs/vectorinstitute/repositories)
 
 If you'd like to use `vec-inf` on your own Slurm cluster, you would need to update the configuration files, there are 3 ways to do it:
-* Clone the repository and update the `environment.yaml` and the `models.yaml` file in [`vec_inf/config`](vec_inf/config/), then install from source by running `pip install .`.
-* The package would try to look for cached configuration files in your environment before using the default configuration. The default cached configuration directory path points to `/model-weights/vec-inf-shared`, you would need to create an `environment.yaml` and a `models.yaml` following the format of these files in [`vec_inf/config`](vec_inf/config/).
-* [OPTIONAL] The package could also look for an enviroment variable `VEC_INF_CONFIG_DIR`. You can put your `environment.yaml` and `models.yaml` in a directory of your choice and set the enviroment variable `VEC_INF_CONFIG_DIR` to point to that location.
+
+- Clone the repository and update the `environment.yaml` and the `models.yaml` file in `[vec_inf/config](vec_inf/config/)`, then install from source by running `pip install .`.
+- The package would try to look for cached configuration files in your environment before using the default configuration. The default cached configuration directory path points to `/model-weights/vec-inf-shared`, you would need to create an `environment.yaml` and a `models.yaml` following the format of these files in `[vec_inf/config](vec_inf/config/)`.
+- [OPTIONAL] The package could also look for an enviroment variable `VEC_INF_CONFIG_DIR`. You can put your `environment.yaml` and `models.yaml` in a directory of your choice and set the enviroment variable `VEC_INF_CONFIG_DIR` to point to that location.
 
 ## Usage
 
@@ -39,24 +42,26 @@ We will use the Llama 3.1 model as example, to launch an OpenAI compatible infer
 ```bash
 vec-inf launch Meta-Llama-3.1-8B-Instruct
 ```
+
 You should see an output like the following:
 
-<img width="720" alt="launch_image" src="./docs/assets/launch.png" />
+
 
 **NOTE**: You can set the required fields in the environment configuration (`environment.yaml`), it's a mapping between required arguments and their corresponding environment variables. On the Vector **Killarney** Cluster environment, the required fields are:
-  * `--account`, `-A`: The Slurm account, this argument can be set to default by setting environment variable `VEC_INF_ACCOUNT`.
-  * `--work-dir`, `-D`: A working directory other than your home directory, this argument can be set to default by seeting environment variable `VEC_INF_WORK_DIR`.
 
-Models that are already supported by `vec-inf` would be launched using the cached configuration (set in [slurm_vars.py](vec_inf/client/slurm_vars.py)) or [default configuration](vec_inf/config/models.yaml). You can override these values by providing additional parameters. Use `vec-inf launch --help` to see the full list of parameters that can be overriden. You can also launch your own custom model as long as the model architecture is supported by the underlying inference engine. For detailed instructions on how to customize your model launch, check out the [`launch` command section in User Guide](https://vectorinstitute.github.io/vector-inference/latest/user_guide/#launch-command). During the launch process, relevant log files and scripts will be written to a log directory (default to `.vec-inf-logs` in your home directory), and a cache directory (`.vec-inf-cache`) will be created in your working directory (defaults to your home directory if not specified or required) for torch compile cache.
+- `--account`, `-A`: The Slurm account, this argument can be set to default by setting environment variable `VEC_INF_ACCOUNT`.
+- `--work-dir`, `-D`: A working directory other than your home directory, this argument can be set to default by seeting environment variable `VEC_INF_WORK_DIR`.
+
+Models that are already supported by `vec-inf` would be launched using the cached configuration (set in [slurm_vars.py](vec_inf/client/slurm_vars.py)) or [default configuration](vec_inf/config/models.yaml). You can override these values by providing additional parameters. Use `vec-inf launch --help` to see the full list of parameters that can be overriden. You can also launch your own custom model as long as the model architecture is supported by the underlying inference engine. For detailed instructions on how to customize your model launch, check out the `[launch` command section in User Guide](https://vectorinstitute.github.io/vector-inference/latest/user_guide/#launch-command). During the launch process, relevant log files and scripts will be written to a log directory (default to `.vec-inf-logs` in your home directory), and a cache directory (`.vec-inf-cache`) will be created in your working directory (defaults to your home directory if not specified or required) for torch compile cache.
 
 #### Other commands
 
-* `batch-launch`: Launch multiple model inference servers at once, currently ONLY single node models supported,
-* `status`: Check the status of all `vec-inf` jobs, or a specific job by providing its job ID.
-* `metrics`: Streams performance metrics to the console.
-* `shutdown`: Shutdown a model by providing its Slurm job ID.
-* `list`: List all available model names, or view the default/cached configuration of a specific model.
-* `cleanup`: Remove old log directories, use `--help` to see the supported filters. Use `--dry-run` to preview what would be deleted.
+- `batch-launch`: Launch multiple model inference servers at once, currently ONLY single node models supported,
+- `status`: Check the status of all `vec-inf` jobs, or a specific job by providing its job ID.
+- `metrics`: Streams performance metrics to the console.
+- `shutdown`: Shutdown a model by providing its Slurm job ID.
+- `list`: List all available model names, or view the default/cached configuration of a specific model.
+- `cleanup`: Remove old log directories, use `--help` to see the supported filters. Use `--dry-run` to preview what would be deleted.
 
 For more details on the usage of these commands, refer to the [User Guide](https://vectorinstitute.github.io/vector-inference/user_guide/)
 
@@ -73,13 +78,8 @@ client = VecInfClient()
 response = client.launch_model("Meta-Llama-3.1-8B-Instruct")
 job_id = response.slurm_job_id
 status = client.get_status(job_id)
-if status.status == ModelStatus.READY:
+if status == ModelStatus.READY:
     print(f"Model is ready at {status.base_url}")
-# Alternatively, use wait_until_ready which will either return a StatusResponse or throw a ServerError
-try:
-    status = wait_until_ready(job_id)
-    except ServerError as e:
-    print(f"Model launch failed: {e}")
 client.shutdown_model(job_id)
 ```
 
@@ -91,7 +91,7 @@ With every model launch, a Slurm script will be generated dynamically based on t
 
 ## Send inference requests
 
-Once the inference server is ready, you can start sending in inference requests. We provide example scripts for sending inference requests in [`examples`](examples) folder. Make sure to update the model server URL and the model weights location in the scripts. For example, you can run `python examples/inference/llm/chat_completions.py`, and you should expect to see an output like the following:
+Once the inference server is ready, you can start sending in inference requests. We provide example scripts for sending inference requests in `[examples](examples)` folder. Make sure to update the model server URL and the model weights location in the scripts. For example, you can run `python examples/inference/llm/chat_completions.py`, and you should expect to see an output like the following:
 
 ```json
 {
@@ -125,17 +125,23 @@ Once the inference server is ready, you can start sending in inference requests.
 }
 
 ```
+
 **NOTE**: Certain models don't adhere to OpenAI's chat template, e.g. Mistral family. For these models, you can either change your prompt to follow the model's default chat template or provide your own chat template via `--chat-template: TEMPLATE_PATH`.
 
 ## SSH tunnel from your local device
+
 If you want to run inference from your local device, you can open a SSH tunnel to your cluster environment like the following:
+
 ```bash
 ssh -L 8081:10.1.1.29:8081 username@v.vectorinstitute.ai -N
 ```
+
 The example provided above is for the Vector Killarney cluster, change the variables accordingly for your environment. The IP address for the compute nodes on Killarney follow `10.1.1.XX` pattern, where `XX` is the GPU number (`kn029` -> `29` in this example).
 
 ## Reference
+
 If you found Vector Inference useful in your research or applications, please cite using the following BibTeX template:
+
 ```
 @software{vector_inference,
   title        = {Vector Inference: Efficient LLM inference on Slurm clusters},
@@ -146,3 +152,4 @@ If you found Vector Inference useful in your research or applications, please ci
   url          = {https://github.com/VectorInstitute/vector-inference}
 }
 ```
+

--- a/vec_inf/client/api.py
+++ b/vec_inf/client/api.py
@@ -71,7 +71,7 @@ class VecInfClient:
 
     Examples
     --------
-    >>> from vec_inf.api import VecInfClient
+    >>> from vec_inf.client import VecInfClient
     >>> client = VecInfClient()
     >>> response = client.launch_model("Meta-Llama-3.1-8B-Instruct")
     >>> job_id = response.slurm_job_id

--- a/venv.sh
+++ b/venv.sh
@@ -12,7 +12,7 @@ export UV_CACHE_DIR=/scratch/$(whoami)/uv_cache
 
 # To see if the cache directory is set correctly, run the following command
 # uv config get cache-dir
-echo "Cache directory set to: $(uv config get cache-dir)"
+echo "Cache directory set to: $(uv cache dir)"
 
 # Install dependencies via uv
 uv sync


### PR DESCRIPTION
# PR Type
Fix

# Short Description
1. Error while running `venv.sh`
```bash
$ bash venv.sh
:
error: unrecognized subcommand 'config'

Usage: uv [OPTIONS] <COMMAND>

For more information, try '--help'.
:
```
2. Errors in example script in `README.md`

```bash
 from vec_inf.api import VecInfClient
ModuleNotFoundError: No module named 'vec_inf.api'
```

```bash
if status == ModelStatus.READY:
                 ^^^^^^^^^^^
NameError: name 'ModelStatus' is not defined
```

```bash
from vec_inf.client import wait_until_ready
ImportError: cannot import name 'wait_until_ready' from 'vec_inf.client'
```

3. Fix docstring in `vec_inf/client/api.py`
```bash
 from vec_inf.api import VecInfClient
ModuleNotFoundError: No module named 'vec_inf.api'
```

# Tests Added

1. `bash venv.sh`
```bash
$ bash venv.sh
downloading uv 0.11.14 x86_64-unknown-linux-gnu
installing to /h/araval/.local/bin
  uv
  uvx
everything's installed!
Cache directory set to: /scratch/araval/uv_cache
Resolved 373 packages in 46ms
Checked 85 packages in 31ms
```

2.  Run script with changes and launch Qwen3 model:
```bash
$ uv run vec-inf status
┏━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Job ID ┃ Model Name ┃ Status ┃ Base URL              ┃
┡━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
│ 351427 │ Qwen3-8B   │ READY  │ http://bn083:44472/v1 │
│ 351428 │ Qwen3-8B   │ READY  │ http://bn083:64012/v1 │
│ 351429 │ Qwen3-8B   │ READY  │ http://bn083:23021/v1 │
└────────┴────────────┴────────┴───────────────────────┘
```
