### PR TITLE
Skip docker build/push job for dependabot PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,11 @@ permissions:
 jobs:
   push_to_registry:
     name: Build and push Docker images
+    # Dependabot PRs never receive repository secrets (GitHub withholds them
+    # from dependabot-triggered runs), so GCP auth always fails here. Skip
+    # the job for those PRs instead of reporting a false CI failure; the
+    # real image build/push still runs on merge to main and on release.
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     runs-on:
       - ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
- Dependabot-triggered workflow runs never receive repository secrets (GitHub withholds them by design), so the `google-github-actions/auth` step in the docker workflow always fails on dependabot PRs that touch `uv.lock`, e.g. #301, #300, #299, #298, #294, #292, #291, #289, #288, #285, #284, #282, #281.
- This adds `if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'` to skip the job in that case instead of reporting a false CI failure. The real image build/push still runs on push to `main` and on release.

## Test plan
- [ ] Confirm the docker job is skipped (not failed) on a rebase of an open dependabot PR after this merges
- [ ] Confirm docker build/push still runs normally on merge to `main`