### PR TITLE
Skip Codecov upload for dependabot PRs

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -82,10 +82,17 @@ jobs:
           uv run --frozen pytest tests/test_imports.py
 
       - name: Import Codecov GPG public key
+        if: github.actor != 'dependabot[bot]'
         run: |
           gpg --keyserver keyserver.ubuntu.com --recv-keys 806BB28AED779869
 
+      # Dependabot PRs never receive repository secrets (GitHub withholds
+      # them from dependabot-triggered runs), so CODECOV_TOKEN is empty and
+      # this step fails with "Token required because branch is protected",
+      # taking down the whole job even though the tests above passed. Skip
+      # the upload in that case.
       - name: Upload coverage to Codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Follow-up to #304. Dependabot-triggered workflow runs don't receive repository secrets, so `CODECOV_TOKEN` is empty in `unit_tests.yml`, and the Codecov upload step fails with `Token required because branch is protected` (`fail_ci_if_error: true`). This takes down the whole `unit-tests` job even though pytest itself passes — visible on nearly every open dependabot PR (e.g. #301, #300, #299, #298, #294, #292, #291, #290, #288, #282), and is why they still show a red "unit-tests" check after rebasing onto the #304 fix.
- Skip the GPG import and Codecov upload steps when `github.actor == 'dependabot[bot]'`, same pattern as the docker job fix.

## Test plan
- [ ] Confirm unit-tests job passes (Codecov steps skipped) on a rebase of an open dependabot PR after this merges
- [ ] Confirm Codecov upload still runs normally on merge to `main`